### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]
@@ -68,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint]
     if: github.event_name == 'release'
+    permissions:
+      contents: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jadmadi/Go-OPML/security/code-scanning/4](https://github.com/jadmadi/Go-OPML/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow to restrict the permissions granted to jobs. The best approach is to set a minimal `permissions` block at the workflow root, such as `contents: read`, which will apply to all jobs by default. For jobs that require additional permissions (such as the `build` job, which uploads release assets), we can override the permissions at the job level to grant only the necessary write access (e.g., `contents: read`, `packages: read`, `pull-requests: write`, `issues: write`, `deployments: write`, or specifically `contents: write` if needed for releases). In this workflow, the `build` job uses `softprops/action-gh-release`, which requires `contents: write` to upload release assets. Therefore, we should:

- Add `permissions: contents: read` at the workflow root (top of the file).
- Add `permissions: contents: write` to the `build` job.

No additional imports or definitions are needed; only the YAML structure is changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
